### PR TITLE
Nexon Old Browser Security Update

### DIFF
--- a/GameStarter/Program.cs
+++ b/GameStarter/Program.cs
@@ -25,7 +25,68 @@ namespace GameStarter
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
+            CheckUpdateIEVersion();
+
             Application.Run(new BrowserForm());
+        }
+
+        static void CheckUpdateIEVersion()
+        {
+            //Reference: https://social.msdn.microsoft.com/Forums/vstudio/en-US/bc469203-cb4a-4477-a8b3-996121b424e6/webbrowser?forum=vbgeneral
+
+            string AppName = System.Reflection.Assembly.GetExecutingAssembly().GetName().Name;
+            int VersionCode;
+            string Version = "";
+            var ieVersion = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Internet Explorer").GetValue("svcUpdateVersion");
+
+            if (ieVersion is null)
+            {
+                ieVersion = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Internet Explorer").GetValue("Version");
+            }
+
+            if (ieVersion is object)
+            {
+                Version = ieVersion.ToString().Substring(0, ieVersion.ToString().IndexOf('.'));
+                switch (Version ?? "")
+                {
+                    case "10":
+                        {
+                            VersionCode = 10001;
+                            break;
+                        }
+
+                    default:
+                        {
+                            if (Convert.ToInt32(Version) >= 11)
+                            {
+                                VersionCode = 11001;
+                            }
+                            else
+                            {
+                                MessageBox.Show("IE Version not supported, must be 10 or higher.");
+                                throw new Exception("IE Version not supported, must be 10 or higher.");
+                            }
+
+                            break;
+                        }
+                }
+            }
+            else
+            {
+                throw new Exception("Registry error");
+            }
+
+            // Check if the right emulation is set
+            // if not, Set Emulation to highest level possible on the user machine
+            string Root = @"HKEY_CURRENT_USER\";
+            string Key = @"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION";
+
+            string CurrentSetting = Convert.ToString((Microsoft.Win32.Registry.CurrentUser.OpenSubKey(Key).GetValue(AppName + ".exe")));
+
+            if (CurrentSetting is null || CurrentSetting == "" || Convert.ToInt32(CurrentSetting) != VersionCode)
+            {
+                Microsoft.Win32.Registry.SetValue(Root + Key, AppName + ".exe", VersionCode);
+            }
         }
     }
 }

--- a/GameStarter/Properties/AssemblyInfo.cs
+++ b/GameStarter/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Requirements
 The application requires .NET Framework 4.7, you can find them on microsoft's website: https://www.microsoft.com/net/download/dotnet-framework-runtime
+As of 2/24/2021, Nexon changed security settings on their website(s), and now require IE version 10 or higher to function properly. This application has been adjusted to work with only IE 10 or higher, and will not function otherwise. If you are on an older computer, seek common Windows update guidance and/or download the latest IE version for your computer.
 
 # How to use
 First thing is that you must have the NGM (Nexon Game Manager) installed.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Requirements
 The application requires .NET Framework 4.7, you can find them on microsoft's website: https://www.microsoft.com/net/download/dotnet-framework-runtime
+
 As of 2/24/2021, Nexon changed security settings on their website(s), and now require IE version 10 or higher to function properly. This application has been adjusted to work with only IE 10 or higher, and will not function otherwise. If you are on an older computer, seek common Windows update guidance and/or download the latest IE version for your computer.
 
 # How to use


### PR DESCRIPTION
As of 2/24/2021, Nexon changed security settings on their website(s), and now requires IE version 10 or higher to function properly. IE versions 7, 8, and 9 no longer create the proper cookies requires for launch and the WebBrowser class defaults to IE7. This change adjusts the FEATURE_BROWSER_EMULATION registry key and adds/updates an entry for GameStarter.exe to use IE 10 or 11 (whichever is the lowest present on the host machine). If IE 9 or lower is the latest, it will error out and not allow the application to run. Updated app to version 1.3.

Note: I saw you made updates on your end, I just happened to not send this PR till this morning, but this change does not require any change in the framework or additional downloads required. If you wish to stay the course of Webview2, then feel free to disregard this. I also tried to send a friend request on discord so I can DM you to discuss this; however, you can disregard it if you wish to keep things as you have changed.